### PR TITLE
更新 component  和 workflowSourceDag (#36)

### DIFF
--- a/pkg/common/schema/workflow.go
+++ b/pkg/common/schema/workflow.go
@@ -64,6 +64,10 @@ type Component interface {
 	GetParameters() map[string]interface{}
 	GetCondition() string
 	GetLoopArgument() interface{}
+
+	// 下面几个Update 函数在进行模板替换的时候会用到
+	UpdateCondition(string)
+	UpdateLoopArguemt(interface{})
 }
 
 type WorkflowSourceStep struct {
@@ -108,13 +112,21 @@ func (s *WorkflowSourceStep) GetLoopArgument() interface{} {
 	return s.LoopArgument
 }
 
+func (s *WorkflowSourceStep) UpdateCondition(condition string) {
+	s.Condition = condition
+}
+
+func (s *WorkflowSourceStep) UpdateLoopArguemt(loopArgument interface{}) {
+	s.LoopArgument = loopArgument
+}
+
 type WorkflowSourceDag struct {
 	LoopArgument interface{}            `yaml:"loop_argument"`
 	Condition    string                 `yaml:"condition"`
 	Parameters   map[string]interface{} `yaml:"parameters"`
 	Deps         string                 `yaml:"deps"`
 	Artifacts    Artifacts              `yaml:"artifacts"`
-	EntryPoints  map[string]interface{} `yaml:"entry_points"`
+	EntryPoints  map[string]Component   `yaml:"entry_points"`
 }
 
 func (d *WorkflowSourceDag) GetDeps() []string {
@@ -146,6 +158,19 @@ func (d *WorkflowSourceDag) GetLoopArgument() interface{} {
 	return d.LoopArgument
 }
 
+func (d *WorkflowSourceDag) UpdateCondition(condition string) {
+	d.Condition = condition
+}
+
+func (d *WorkflowSourceDag) UpdateLoopArguemt(loopArgument interface{}) {
+	d.LoopArgument = loopArgument
+}
+
+func (d *WorkflowSourceDag) GetSubComponet(subComponentName string) (Component, bool) {
+	sc, ok := d.EntryPoints[subComponentName]
+	return sc, ok
+}
+
 type Cache struct {
 	Enable         bool   `yaml:"enable"           json:"enable"`
 	MaxExpiredTime string `yaml:"max_expired_time" json:"maxExpiredTime"` // seconds
@@ -160,7 +185,7 @@ type WorkflowSource struct {
 	Name           string                         `yaml:"name"`
 	DockerEnv      string                         `yaml:"docker_env"`
 	EntryPoints    WorkflowSourceDag              `yaml:"entry_points"`
-	Templates      map[string]interface{}         `yaml:"templates"`
+	Components     map[string]Component           `yaml:"components"`
 	Cache          Cache                          `yaml:"cache"`
 	Parallelism    int                            `yaml:"parallelism"`
 	Disabled       string                         `yaml:"disabled"`

--- a/pkg/pipeline/common/const.go
+++ b/pkg/pipeline/common/const.go
@@ -21,13 +21,16 @@ type ViewType string
 
 const (
 	// 如果有增加新的系统变量，记得需要同步更新 SysParamNameList
-	SysParamNamePFRunID    = "PF_RUN_ID"
-	SysParamNamePFFsID     = "PF_FS_ID"
-	SysParamNamePFJobID    = "PF_JOB_ID"
-	SysParamNamePFStepName = "PF_STEP_NAME"
-	SysParamNamePFFsName   = "PF_FS_NAME"
-	SysParamNamePFUserID   = "PF_USER_ID"
-	SysParamNamePFUserName = "PF_USER_NAME"
+	SysParamNamePFRunID        = "PF_RUN_ID"
+	SysParamNamePFFsID         = "PF_FS_ID"
+	SysParamNamePFJobID        = "PF_JOB_ID"
+	SysParamNamePFStepName     = "PF_STEP_NAME"
+	SysParamNamePFFsName       = "PF_FS_NAME"
+	SysParamNamePFUserID       = "PF_USER_ID"
+	SysParamNamePFUserName     = "PF_USER_NAME"
+	SysParamNamePFLoopArgument = "PF_LOOP_ARGUMENT"
+
+	PF_PARENT = "PF_PARENT"
 
 	WfExtraInfoKeySource   = "Source" // pipelineID or yamlPath
 	WfExtraInfoKeyUserName = "UserName"
@@ -47,6 +50,8 @@ const (
 	FieldEnv             = "env"
 	FieldInputArtifacts  = "inputArtifacts"
 	FieldOutputArtifacts = "outputArtifacts"
+	FieldCondition       = "condition"
+	FieldLoopArguemt     = "loop_argument"
 
 	CacheStrategyConservative = "conservative"
 	CacheStrategyAggressive   = "aggressive"
@@ -62,6 +67,11 @@ const (
 	RegExpIncludingUpstreamTpl = `\{\{(\s)*[a-zA-Z0-9-]+\.[a-zA-Z0-9_]+(\s)*\}\}`     // 包含 {{xx-xx.xx_xx}}
 	RegExpIncludingTpl         = `\{\{(\s)*([a-zA-Z0-9-]*\.?[a-zA-Z0-9_]+)?(\s)*\}\}` // 包含 {{xx-xx.xx_xx}} 或 {{xx_xx}}
 
+	// condition 字段中引用的 artifact 支持最大空间， 单位为 byte
+	ConditionArtifactMaxSize = 1024 // 1KB
+
+	// loop_argument 字段中引用的 artifact 支持最大空间， 单位为 byte
+	LoopArgumentArtifactMaxSize = 1024 * 1024 // 1MB
 )
 
 var SysParamNameList []string = []string{
@@ -72,4 +82,5 @@ var SysParamNameList []string = []string{
 	SysParamNamePFFsName,
 	SysParamNamePFUserID,
 	SysParamNamePFUserName,
+	SysParamNamePFLoopArgument,
 }


### PR DESCRIPTION
* add Node interface

* 删除PF_RUN_TIME 相关逻辑

* 1.4.2 lt (#26)

* 1.4.2 exp (#24)

* add Node interface

* 删除PF_RUN_TIME 相关逻辑

* update WorkflowSource && RuntimeView (#25)

Co-authored-by: Cao Yang <51772319+StevenYangCao@users.noreply.github.com>

* 1.4.2 lt (#26)

* 1.4.2 exp (#24)

* add Node interface

* 删除PF_RUN_TIME 相关逻辑

* update WorkflowSource && RuntimeView (#25)

Co-authored-by: Cao Yang <51772319+StevenYangCao@users.noreply.github.com>

* 同步的 go.mod

* add condition calculator

* update NodeView to ComponentView

* change Node to Component

* update jobId to LogRunCacheRequest and LogRunArtifactRequest

* update callback function sign

* update cache, delete stepName from conservativeFirstCacheKey

* delete deps info from job

* 1、update

* mv step.go to stepRuntime.go

* add Getxxx Func to Component

* add componentRuntime

* update comment of ppl

* update workflowDag.EntryPoint

* update workflowSource.Template to workflowSource.Components

* update the type of workflowSource.Components from interface{} to components

Co-authored-by: Cao Yang <51772319+StevenYangCao@users.noreply.github.com>